### PR TITLE
docs: align attestation binding formula

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -458,13 +458,13 @@ AMD SEV-SNP attestation reports are 1184 bytes with the following key fields:
 The 64-byte `report_data` field is used to bind the attestation to the specific execution:
 
 ```
-report_data = SHA-256(session_id || config_hash || nonce || output_hash)
+report_data = SHA-256(session_id || config_hash || output_hash || timestamp)
 ```
 
 This ensures:
 - Output cannot be swapped (bound to `output_hash`)
 - Configuration cannot be changed (bound to `config_hash`)
-- Session cannot be replayed (bound to unique `session_id` + `nonce`)
+- Session cannot be replayed (bound to unique `session_id` + `timestamp`)
 
 ### Signature Chain Validation
 


### PR DESCRIPTION
Aligns binding formula documentation with the v1.0 spec.
Related Issue: #15 