### PR TITLE
docs: sync v1.0 core docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ This repository represents the open-core component of the Axiom system.
 ## Links
 
 - Integration Guide: [`docs/INTEGRATION.md`](docs/INTEGRATION.md)
+- Docs Site: https://github.com/AxiomInfra/axiom-core-docs
 - Architecture: [`docs/architecture.md`](docs/architecture.md)
 - Security: [`docs/security.md`](docs/security.md)
 - Roadmap: [`docs/roadmap.md`](docs/roadmap.md)

--- a/docs/ENCLAVE_INTERFACE.md
+++ b/docs/ENCLAVE_INTERFACE.md
@@ -1,5 +1,7 @@
 # Enclave Interface Specification
 
+> Canonical docs site: https://github.com/AxiomInfra/axiom-core-docs
+
 **Version:** 1.0  
 **Platform:** AMD SEV-SNP  
 **Last Updated:** 2026-01-21

--- a/docs/INTEGRATION.md
+++ b/docs/INTEGRATION.md
@@ -1,5 +1,7 @@
 # Axiom Core Integration Guide
 
+> Canonical docs site: https://github.com/AxiomInfra/axiom-core-docs
+
 **Version:** 1.0  
 **Last Updated:** 2026-01-21  
 **Audience:** Developers integrating Axiom Core into applications

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,5 +1,7 @@
 # Axiom Core v1.0 Architecture
 
+> Canonical docs site: https://github.com/AxiomInfra/axiom-core-docs
+
 **Note:** Attested execution is opt-in and requires the native enclave runner. Simulator mode provides no security guarantees.
 
 ## Overview

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,5 +1,7 @@
 # Axiom Core Roadmap
 
+> Canonical docs site: https://github.com/AxiomInfra/axiom-core-docs
+
 ## Overview
 
 This roadmap outlines the evolution from software-only boundary enforcement (v0.x) to hardware-backed attestation (v1.0) and future privacy goals (v2.x+). It is directional and may change based on hardware availability and integration feedback.

--- a/docs/security.md
+++ b/docs/security.md
@@ -1,5 +1,7 @@
 # Axiom Core Security Model (v1.0)
 
+> Canonical docs site: https://github.com/AxiomInfra/axiom-core-docs
+
 **Version:** 1.0  
 **Last Updated:** 2026-01-21  
 **Status:** v1.0 (attested tier requires native runner)


### PR DESCRIPTION
Adds canonical docs site pointers and aligns v1.0 docs headers with current repo status.